### PR TITLE
Remove simple-main imports

### DIFF
--- a/src/ai/command-interpreter.ts
+++ b/src/ai/command-interpreter.ts
@@ -7,7 +7,7 @@
 
 import { SimpleAIService } from './simple-ai-service';
 import { RealAIService } from './real-ai-service';
-import { GameState, SimpleNPC } from '../simple-main';
+
 import { CommandContext } from './enhanced-ai-service';
 import { envLoader } from '../utils/env-loader';
 

--- a/src/ai/enhanced-ai-service.ts
+++ b/src/ai/enhanced-ai-service.ts
@@ -12,7 +12,7 @@
 import { AIService } from './ai-service';
 import { EnhancedContextManager } from './enhanced-context-manager';
 import { GameScenario } from './memory/context-optimizer';
-import { GameState } from '../simple-main';
+import { GameState } from '../core/interfaces/game';
 
 /**
  * Enhanced AI service configuration

--- a/src/ai/enhanced-context-manager.ts
+++ b/src/ai/enhanced-context-manager.ts
@@ -6,7 +6,7 @@
  * relationship tracking, context optimization, and prompt templates.
  */
 
-import { GameState } from '../simple-main';
+import { GameState } from '../core/interfaces/game';
 import { MemoryManager } from './memory/memory-manager';
 import { RelationshipTracker } from './memory/relationship-tracker';
 import { ContextOptimizer, GameScenario } from './memory/context-optimizer';

--- a/src/ai/integration/README.md
+++ b/src/ai/integration/README.md
@@ -19,7 +19,7 @@ The enhanced context management system consists of several specialized component
 ```typescript
 import { AIService } from '../ai-service-wrapper';
 import { integrateEnhancedContext } from './integration/context-integration';
-import { GameState } from '../simple-main';
+import { GameState } from '../core/interfaces/game';
 
 // Create base AI service
 const baseService = new AIService();

--- a/src/ai/integration/context-integration.ts
+++ b/src/ai/integration/context-integration.ts
@@ -8,7 +8,7 @@
 import { AIService } from '../ai-service-wrapper';
 import { EnhancedContextManager, EnhancedContextManagerConfig } from '../enhanced-context-manager';
 import { EnhancedAIService } from '../enhanced-ai-service';
-import { GameState } from '../../simple-main';
+import { GameState } from '../../core/interfaces/game';
 import { GameScenario } from '../memory/context-optimizer';
 
 /**

--- a/src/ai/memory/context-optimizer.ts
+++ b/src/ai/memory/context-optimizer.ts
@@ -7,7 +7,7 @@
 
 import { MemoryManager, MemoryType, MemoryItem } from './memory-manager';
 import { RelationshipTracker } from './relationship-tracker';
-import { GameState } from '../../simple-main';
+import { GameState } from '../../core/interfaces/game';
 
 /**
  * Context window section

--- a/src/ai/memory/memory-manager.ts
+++ b/src/ai/memory/memory-manager.ts
@@ -5,7 +5,7 @@
  * relevant narrative events and optimizing token usage for context windows.
  */
 
-import { GameState, SimpleNPC, SimpleCharacter, SimpleLocation } from '../../simple-main';
+import { GameState } from '../../core/interfaces/game';
 
 /**
  * Types of memory items that can be stored

--- a/src/ai/memory/relationship-tracker.ts
+++ b/src/ai/memory/relationship-tracker.ts
@@ -5,7 +5,6 @@
  * sentiment, trust, and interaction history to enhance narrative coherence.
  */
 
-import { SimpleNPC, SimpleCharacter } from '../../simple-main';
 
 /**
  * Relationship strength values

--- a/src/ai/prompts/prompt-templates.ts
+++ b/src/ai/prompts/prompt-templates.ts
@@ -7,7 +7,6 @@
  */
 
 import { GameScenario } from '../memory/context-optimizer';
-import { GameState } from '../../simple-main';
 
 /**
  * Prompt template interface

--- a/src/ai/simple-ai-service.ts
+++ b/src/ai/simple-ai-service.ts
@@ -7,7 +7,6 @@
  * to generate responses.
  */
 
-import { SimpleNPC } from '../simple-main';
 
 // Simple AI context to maintain continuity
 interface SimpleAIContext {

--- a/src/examples/enhanced-ai-example.ts
+++ b/src/examples/enhanced-ai-example.ts
@@ -7,7 +7,7 @@
 
 import { AIService } from '../ai/ai-service-wrapper';
 import { EnhancedAIService } from '../ai/enhanced-ai-service';
-import { GameState } from '../simple-main';
+import { GameState } from '../core/interfaces/game';
 import { GameScenario } from '../ai/memory/context-optimizer';
 import { 
   integrateEnhancedContext, 

--- a/src/examples/game-integration-example.ts
+++ b/src/examples/game-integration-example.ts
@@ -7,7 +7,7 @@
 
 import { AIService } from '../ai/ai-service-wrapper';
 import { EnhancedAIService } from '../ai/enhanced-ai-service';
-import { GameState } from '../simple-main';
+import { GameState } from '../core/interfaces/game';
 import { GameScenario } from '../ai/memory/context-optimizer';
 import { 
   integrateEnhancedContext, 

--- a/src/examples/real-ai-example.ts
+++ b/src/examples/real-ai-example.ts
@@ -7,7 +7,43 @@
 
 import { RealAIService } from '../ai/real-ai-service';
 import { CommandInterpreter } from '../ai/command-interpreter';
-import { SimpleCharacter, SimpleNPC } from '../simple-main';
+interface SimpleCharacter {
+  id: string;
+  name: string;
+  race: string;
+  class: string;
+  level: number;
+  experiencePoints: number;
+  hitPoints: { current: number; maximum: number };
+  armorClass: number;
+  initiative: number;
+  speed: number;
+  proficiencyBonus: number;
+  abilityScores: Record<string, { score: number; modifier: number }>;
+  attacks: Array<{ name: string; damage: string; range: number }>;
+  inventory: {
+    gold: number;
+    items: Array<{
+      id: string;
+      name: string;
+      description: string;
+      weight: number;
+      value: number;
+      quantity: number;
+      category: string;
+    }>;
+  };
+  conditions: any[];
+}
+
+interface SimpleNPC {
+  id: string;
+  name: string;
+  race: string;
+  profession: string;
+  trait: string;
+  location: string;
+}
 import { envLoader } from '../utils/env-loader';
 import { NarrativeContext, CommandContext } from '../ai/enhanced-ai-service';
 import * as readline from 'readline';


### PR DESCRIPTION
## Summary
- drop unused imports from nonexistent `simple-main`
- update example code and docs to reference core interfaces
- add local example interfaces

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842ceffea14832397db93be122dffd0